### PR TITLE
Make optional character of AWS S3 and MotherDuck account more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ TRANSFORM_S3_PATH_OUTPUT=s3://my-output-bucket/ # For transform pipeline, output
 ### Requirements
 
 - [GCP account](https://console.cloud.google.com/)
-- AWS S3 bucket (optional to push data to S3) and AWS credentials (at the default `~/.aws/credentials` path) that has write access to the bucket
-- [MotherDuck account](https://app.motherduck.com/) (optional to push data to MotherDuck)
+- OPTIONAL: AWS S3 bucket (optional to push data to S3) and AWS credentials (at the default `~/.aws/credentials` path) that has write access to the bucket
+- OPTIONAL: [MotherDuck account](https://app.motherduck.com/) (optional to push data to MotherDuck)
 
 ### Run
 Once you fill your `.env` file, do the following :


### PR DESCRIPTION
Upon first reading of this section of the README:

```
Requirements
[GCP account](https://console.cloud.google.com/)
AWS S3 bucket (optional to push data to S3) and AWS credentials (at the default ~/.aws/credentials path) that has write access to the bucket
[MotherDuck account](https://app.motherduck.com/) (optional to push data to MotherDuck)
```

I was a bit triggered that a MotherDuck account was required (it is in the "Requirements" list, so that is not so crazy). And because the MotherDuck link is underlined and the AWS S3 is not, it seemed more prominent.

Only on further reading, it became clear that MotherDuck account and/or AWS S3 are optional.

So, I suggest to make that optional character more prominent, e.g. as in this PR.