### PR TITLE
fix: resolve docker build exec format error and update dependencies

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
         run: echo ${{ secrets.GHA_PACKAGES }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 ARG PLATFORM=amd64
 
 # Stage 1: Base
-FROM --platform=linux/${PLATFORM} python:3.12 as base
+FROM --platform=linux/${PLATFORM} python:3.12 AS base
 
 # Install UV via pip
-RUN pip install uv==0.5.5 --no-cache-dir
+RUN pip install uv==0.10.9 --no-cache-dir
 
 # UV environment settings
 ENV UV_LINK_MODE=copy \
@@ -13,7 +13,7 @@ ENV UV_LINK_MODE=copy \
     UV_PYTHON=/usr/local/bin/python3.12
 
 # Stage : Development
-FROM base as development
+FROM base AS development
 # Set working directory
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.cache \
     uv sync --locked
 
 # Stage : Production
-FROM base as production
+FROM base AS production
 # Set working directory
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DBT_FOLDER = transform/pypi_metrics/
 DBT_TARGET = dev
 DBT_DATA_SOURCE = motherduck
 DATABASE_NAME ?= duckdb_stats
+PLATFORM ?= amd64
 DOCKER ?= false
 DOCKER_CMD = 
 DOCKER_IMAGE ?= ghcr.io/$(REPOSITORY)
@@ -51,7 +52,7 @@ pypi-transform-test:
 
 ## Docker 
 build:
-	docker build --label org.opencontainers.image.source=https://github.com/$(GITHUB_REPOSITORY) -t $(DOCKER_IMAGE) --build-arg PLATFORM=arm64 .
+	docker build --label org.opencontainers.image.source=https://github.com/$(GITHUB_REPOSITORY) -t $(DOCKER_IMAGE) --build-arg PLATFORM=$(PLATFORM) .
 
 ## Development
 install: 


### PR DESCRIPTION
Default PLATFORM to amd64 (matching CI runners) instead of hardcoding arm64, update uv from 0.5.5 to 0.10.9, fix FROM/AS casing warnings, and bump GitHub Actions to latest versions.

