### PR TITLE
feat: replace brush selector with drag-to-zoom and remove period filter

### DIFF
--- a/dashboard/components/dashboard.tsx
+++ b/dashboard/components/dashboard.tsx
@@ -10,7 +10,6 @@ import { PythonBarChart } from "./python-bar-chart";
 import { CountryBarChart } from "./country-bar-chart";
 import { AdoptionAreaChart } from "./adoption-area-chart";
 import { DailyDownloadsChart } from "./daily-downloads-chart";
-import { PeriodSelector } from "./period-selector";
 
 function Skeleton({ className }: { className?: string }) {
   return (
@@ -59,13 +58,12 @@ export function Dashboard() {
   const [data, setData] = useState<DashboardData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [periodDays, setPeriodDays] = useState(0);
 
-  const fetchData = useCallback(async (days: number) => {
+  const fetchData = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/stats?days=${days}`);
+      const res = await fetch(`/api/stats?days=0`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
       setData(json);
@@ -77,11 +75,11 @@ export function Dashboard() {
   }, []);
 
   useEffect(() => {
-    fetchData(periodDays);
-  }, [periodDays, fetchData]);
+    fetchData();
+  }, [fetchData]);
 
   if (loading && !data) return <LoadingSkeleton />;
-  if (error && !data) return <ErrorState message={error} onRetry={() => fetchData(periodDays)} />;
+  if (error && !data) return <ErrorState message={error} onRetry={fetchData} />;
   if (!data) return null;
 
   return (
@@ -103,13 +101,7 @@ export function Dashboard() {
         <MonthlyTable data={data.monthlyRecent} />
       </div>
 
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h2 className="text-base font-semibold tracking-tight">Breakdown</h2>
-        <PeriodSelector
-          value={periodDays}
-          onChange={(days) => setPeriodDays(days)}
-        />
-      </div>
+      <h2 className="text-base font-semibold tracking-tight">Breakdown</h2>
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <DailyDownloadsChart data={data.dailyDownloads} periodDays={data.periodDays} />

--- a/dashboard/components/downloads-line-chart.tsx
+++ b/dashboard/components/downloads-line-chart.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import {
   Area,
   AreaChart,
   CartesianGrid,
   XAxis,
   YAxis,
-  Brush,
+  ReferenceArea,
 } from "recharts";
 import {
   ChartContainer,
@@ -30,17 +31,84 @@ interface DownloadsLineChartProps {
 }
 
 export function DownloadsLineChart({ data }: DownloadsLineChartProps) {
+  const [chartData, setChartData] = useState(data);
+  const [refAreaLeft, setRefAreaLeft] = useState<string | null>(null);
+  const [refAreaRight, setRefAreaRight] = useState<string | null>(null);
+  const [isZoomed, setIsZoomed] = useState(false);
+
+  const handleMouseDown = useCallback((e: { activeLabel?: string }) => {
+    if (e?.activeLabel) {
+      setRefAreaLeft(e.activeLabel);
+      setRefAreaRight(null);
+    }
+  }, []);
+
+  const handleMouseMove = useCallback(
+    (e: { activeLabel?: string }) => {
+      if (refAreaLeft && e?.activeLabel) {
+        setRefAreaRight(e.activeLabel);
+      }
+    },
+    [refAreaLeft],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    if (!refAreaLeft || !refAreaRight) {
+      setRefAreaLeft(null);
+      setRefAreaRight(null);
+      return;
+    }
+
+    const idxLeft = data.findIndex((d) => d.week_start_date === refAreaLeft);
+    const idxRight = data.findIndex((d) => d.week_start_date === refAreaRight);
+
+    if (idxLeft === idxRight) {
+      setRefAreaLeft(null);
+      setRefAreaRight(null);
+      return;
+    }
+
+    const [from, to] =
+      idxLeft < idxRight ? [idxLeft, idxRight] : [idxRight, idxLeft];
+
+    setChartData(data.slice(from, to + 1));
+    setIsZoomed(true);
+    setRefAreaLeft(null);
+    setRefAreaRight(null);
+  }, [refAreaLeft, refAreaRight, data]);
+
+  const handleZoomOut = useCallback(() => {
+    setChartData(data);
+    setIsZoomed(false);
+  }, [data]);
+
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Weekly Downloads</CardTitle>
-        <CardDescription>
-          DuckDB Python package downloads aggregated by week
-        </CardDescription>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <div>
+          <CardTitle>Weekly Downloads</CardTitle>
+          <CardDescription>
+            DuckDB Python package downloads aggregated by week
+          </CardDescription>
+        </div>
+        {isZoomed && (
+          <button
+            onClick={handleZoomOut}
+            className="rounded-md border border-input bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            Reset zoom
+          </button>
+        )}
       </CardHeader>
       <CardContent>
         <ChartContainer config={chartConfig} className="aspect-auto h-[250px] w-full">
-          <AreaChart data={data} accessibilityLayer>
+          <AreaChart
+            data={chartData}
+            accessibilityLayer
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+          >
             <defs>
               <linearGradient id="fillWeekly" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="5%" stopColor="var(--color-weekly_downloads)" stopOpacity={0.3} />
@@ -79,14 +147,23 @@ export function DownloadsLineChart({ data }: DownloadsLineChartProps) {
               fill="url(#fillWeekly)"
               strokeWidth={2}
             />
-            <Brush
-              dataKey="week_start_date"
-              height={30}
-              stroke="var(--color-weekly_downloads)"
-              tickFormatter={(v) => formatShortDate(v)}
-            />
+            {refAreaLeft && refAreaRight && (
+              <ReferenceArea
+                x1={refAreaLeft}
+                x2={refAreaRight}
+                fill="var(--color-weekly_downloads)"
+                fillOpacity={0.15}
+                strokeOpacity={0.3}
+                stroke="var(--color-weekly_downloads)"
+              />
+            )}
           </AreaChart>
         </ChartContainer>
+        {!isZoomed && (
+          <p className="mt-2 text-center text-xs text-muted-foreground">
+            Drag on the chart to zoom in
+          </p>
+        )}
       </CardContent>
     </Card>
   );

--- a/dashboard/components/downloads-line-chart.tsx
+++ b/dashboard/components/downloads-line-chart.tsx
@@ -91,17 +91,27 @@ export function DownloadsLineChart({ data }: DownloadsLineChartProps) {
             DuckDB Python package downloads aggregated by week
           </CardDescription>
         </div>
-        {isZoomed && (
+        {isZoomed ? (
           <button
             onClick={handleZoomOut}
             className="rounded-md border border-input bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
           >
             Reset zoom
           </button>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2.5 py-1 text-xs text-muted-foreground">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="11" cy="11" r="8" />
+              <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              <line x1="11" y1="8" x2="11" y2="14" />
+              <line x1="8" y1="11" x2="14" y2="11" />
+            </svg>
+            Drag to zoom
+          </span>
         )}
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className="aspect-auto h-[250px] w-full">
+        <ChartContainer config={chartConfig} className="aspect-auto h-[250px] w-full cursor-crosshair">
           <AreaChart
             data={chartData}
             accessibilityLayer
@@ -159,11 +169,6 @@ export function DownloadsLineChart({ data }: DownloadsLineChartProps) {
             )}
           </AreaChart>
         </ChartContainer>
-        {!isZoomed && (
-          <p className="mt-2 text-center text-xs text-muted-foreground">
-            Drag on the chart to zoom in
-          </p>
-        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Replace the Recharts Brush range selector on the weekly downloads chart with a drag-to-select zoom that looks better on dark theme. Remove the period selector filter below the chart.