### PR TITLE
fix(dashboard): use the public link

### DIFF
--- a/dashboard/lib/motherduck.ts
+++ b/dashboard/lib/motherduck.ts
@@ -17,7 +17,7 @@ async function createConnection(): Promise<DuckDBConnection> {
   });
   const connection = await instance.connect();
   await connection.run(
-    "ATTACH IF NOT EXISTS 'md:duckdb_stats' AS duckdb_stats"
+    "ATTACH IF NOT EXISTS 'md:_share/duckdb_stats/1eb684bf-faff-4860-8e7d-92af4ff9a410' AS duckdb_stats"
   );
   return connection;
 }


### PR DESCRIPTION
## Summary
- ATTACH the `duckdb_stats` database via the public share URL instead of `md:duckdb_stats`, so the dashboard works regardless of which MotherDuck account the `MOTHERDUCK_TOKEN` belongs to.
- Resolves the production 500s on `/api/stats` after the token rotation: `Catalog Error: no database/share named 'duckdb_stats' found`.
- Same share URL already advertised in `dashboard-footer.tsx` and `README.md`.

## Test plan
- [ ] Vercel preview deploys cleanly
- [ ] `curl https://<preview>/api/stats` returns 200 with payload
- [ ] Dashboard loads at the preview URL
- [ ] After merge, www.duckdbstats.com renders without 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)